### PR TITLE
Ошибки обновления при первом запуске

### DIFF
--- a/_mirror/handlers/ids.py
+++ b/_mirror/handlers/ids.py
@@ -147,12 +147,14 @@ def download_ids_update_files(version: str) -> None:
                     log_message = _("IDSv%(version)s error: %(err)s", version=version, err=response.text.strip())
                     write_log(log_type=["system", "updates"], message=log_message)
                     config.license_number = None
-                    return
-
-            # Get current version from database
+                    return            # Get current version from database
             actual_version = get_ids(name=f"ids{version}")
+            current_version = 0
 
-            if actual_version["version"] >= result["version"]:
+            if actual_version is not None and "version" in actual_version:
+                current_version = actual_version["version"]
+
+            if current_version >= result["version"]:
                 log_message = _(
                     "IDSv%(version)s: no new version, current version: %(version)s.%(result_version)s",
                     version=version,

--- a/_mirror/handlers/update_mirror.py
+++ b/_mirror/handlers/update_mirror.py
@@ -59,8 +59,11 @@ def update_mirror():
 
     if config.update_ids_4:  # Update GeoIP database files
         if config.geoip_github:
-            actual_version = get_ids(name=f"ids4")
-            if int(actual_version["version"]) < int(datetime.datetime.now().strftime("%Y%m%d")):
+            actual_version = get_ids(name="ids4")
+            current_version = "0"
+            if actual_version is not None and "version" in actual_version:
+                current_version = actual_version["version"]
+            if int(current_version) < int(datetime.datetime.now().strftime("%Y%m%d")):
                 write_log(
                     log_type="system",
                     message=_(
@@ -82,7 +85,7 @@ def update_mirror():
                     log_type="updates",
                     message=_(
                         "IDSv4: no new version available, current version: 4.%(actual_version)s",
-                        actual_version=actual_version["version"],
+                        actual_version=current_version,
                     ),
                 )
         else:


### PR DESCRIPTION
При первом запуске нет информации о текущей версии. Поэтому ошибка прерывает обновление: 
```
if actual_version["version"] >= result["version"]: 
~~~~~~~~~~~~~~^^^^^^^^^^^
TypeError: 'NoneType' object is not subscriptable
```